### PR TITLE
Update name in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,4 +1,4 @@
-name=arduino-sps
+name=sensirion-sps
 version=0.0.3
 author=Johannes Winkelmann
 maintainer=Johannes Winkelmann <jwi@sensirion.com>


### PR DESCRIPTION
Arduino's library policies don't allow "Arduino" in the name field anymore; change to "sensirion-sps" instead