### PR TITLE
Multiarch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@ To learn more about the SPS30, please visit https://www.sensirion.com/sps30/. Fo
 
 This library is using the code from Sensirion's [embedded-sps](https://github.com/Sensirion/embedded-sps) library, and adding a handful of changes to adapt to Arduino.
 
-Most notably, this is using an alternative [I2C Master Library](https://github.com/DSSCircuits/I2C-Master-Library) to work around the I2C buffer size limit that exists on certain Arduino platform, including the Arduino Uno series.
+Most notably, for AVR based platforms (like Arduino Uno and friends), this is using an alternative [I2C Master Library](https://github.com/DSSCircuits/I2C-Master-Library) to work around the I2C buffer size limit that exists on those boards.
+
+## Compatibility
+
+This library has been tested on the following platforms:
+- AVR based Arduino, like Arduino Uno
+- ESP8266, using v2.5.0 or newer (Tested on Adafruit Feather Huzzah ESP8266)
+- ESP32, using v1.0.1 or newer (Tested on Adafruit Feather Huzzah ESP32)
+- SAMD (tested on Arduino MKR 1010)
+
+**Important Note:** The SPS30 requires 5V input voltage +/-0.5V in order to provide correct output values. When using a 3.3V based Arduino,
+make sure to use the appropriate voltage regulators and level shifters for I2C!
 
 ## Installation
 

--- a/i2c_master_lib.cpp
+++ b/i2c_master_lib.cpp
@@ -69,7 +69,7 @@
 #include <inttypes.h>
 #include "i2c_master_lib.h"
 
-
+#ifdef SPS30_USE_ALT_I2C
 
 uint8_t I2C::bytesAvailable = 0;
 uint8_t I2C::bufferIndex = 0;
@@ -713,3 +713,4 @@ void I2C::lockUp()
 }
 
 I2C I2c = I2C();
+#endif /* SPS30_USE_ALT_I2C */

--- a/i2c_master_lib.h
+++ b/i2c_master_lib.h
@@ -52,12 +52,16 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
+#include "sensirion_arch_config.h"
+
+#ifdef SPS30_USE_ALT_I2C
 
 #if(ARDUINO >= 100)
 #include <Arduino.h>
 #else
 #include <WProgram.h>
 #endif
+
 
 #include <inttypes.h>
 
@@ -133,3 +137,5 @@ class I2C
 extern I2C I2c;
 
 #endif
+
+#endif /* SPS30_USE_ALT_I2C */

--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -31,6 +31,10 @@
 #ifndef SENSIRION_ARCH_CONFIG_H
 #define SENSIRION_ARCH_CONFIG_H
 
+#ifdef __AVR__
+#define SPS30_USE_ALT_I2C
+#endif /* __AVR__ */
+
 /**
  * If your platform does not provide the library stdint.h you have to
  * define the integral types yourself (see below).

--- a/sensirion_common.cpp
+++ b/sensirion_common.cpp
@@ -126,7 +126,7 @@ s16 sensirion_i2c_read_words(u8 address, u16 *data_words, u16 num_words) {
 s16 sensirion_i2c_write_cmd(u8 address, u16 command) {
     u8 buf[SENSIRION_COMMAND_SIZE];
 
-    sensirion_fill_cmd_send_buf(buf, command, NULL, 0);
+    sensirion_fill_cmd_send_buf(buf, command, (uint16_t *)NULL, 0);
     return sensirion_i2c_write(address, buf, SENSIRION_COMMAND_SIZE);
 }
 
@@ -144,7 +144,7 @@ s16 sensirion_i2c_delayed_read_cmd(u8 address, u16 cmd, u32 delay_us,
     s16 ret;
     u8 buf[SENSIRION_COMMAND_SIZE];
 
-    sensirion_fill_cmd_send_buf(buf, cmd, NULL, 0);
+    sensirion_fill_cmd_send_buf(buf, cmd, (uint16_t *)NULL, 0);
     ret = sensirion_i2c_write(address, buf, SENSIRION_COMMAND_SIZE);
     if (ret != STATUS_OK)
         return ret;

--- a/sps30.cpp
+++ b/sps30.cpp
@@ -108,17 +108,17 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement) {
     s16 ret;
     u16 idx;
     union {
-        u16 u16[2];
+        u16 value_u16[2];
         u32 u;
         f32 f;
     } val, data[10];
 
     ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS, SPS_CMD_READ_MEASUREMENT,
-                                 data->u16, SENSIRION_NUM_WORDS(data));
+                                 data->value_u16, SENSIRION_NUM_WORDS(data));
     if (ret != STATUS_OK)
         return ret;
 
-    SENSIRION_WORDS_TO_BYTES(data->u16, SENSIRION_NUM_WORDS(data));
+    SENSIRION_WORDS_TO_BYTES(data->value_u16, SENSIRION_NUM_WORDS(data));
 
     idx = 0;
     val.u = be32_to_cpu(data[idx].u);
@@ -157,17 +157,17 @@ s16 sps30_read_measurement(struct sps30_measurement *measurement) {
 
 s16 sps30_get_fan_auto_cleaning_interval(u32 *interval_seconds) {
     union {
-        u16 u16[2];
-        u32 u32;
+        u16 value_u16[2];
+        u32 value_u32;
     } data;
     s16 ret = sensirion_i2c_read_cmd(SPS_I2C_ADDRESS,
                                      SPS_CMD_AUTOCLEAN_INTERVAL,
-                                     data.u16, SENSIRION_NUM_WORDS(data.u16));
+                                     data.value_u16, SENSIRION_NUM_WORDS(data.value_u16));
     if (ret != STATUS_OK)
         return ret;
 
-    SENSIRION_WORDS_TO_BYTES(data.u16, SENSIRION_NUM_WORDS(data.u16));
-    *interval_seconds = be32_to_cpu(data.u32);
+    SENSIRION_WORDS_TO_BYTES(data.value_u16, SENSIRION_NUM_WORDS(data.value_u16));
+    *interval_seconds = be32_to_cpu(data.value_u32);
 
     return 0;
 }


### PR DESCRIPTION
Pull in our standard Arduino I2C library for platforms other than AVR based ones. Verified that the current stable version of board support packages for SAMD, ESP32 and ESP8266 all have support for I2C receive buffers >= 64 byte