### PR TITLE
Limit i2c buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ This library has been tested on the following platforms:
 **Important Note:** The SPS30 requires 5V input voltage +/-0.5V in order to provide correct output values. When using a 3.3V based Arduino,
 make sure to use the appropriate voltage regulators and level shifters for I2C!
 
+### ESP8266 partial legacy support
+
+This library automatically detects ESP8266 core versions 2.3.0, 2.4.0, 2.4.1 and 2.4.2 and supports a limited
+subset of functionality on there. The following features are not available:
+- Reading out number concentrations,
+- Reading out the average particle size
+- Reading out the serial number
+
 ## Installation
 
 At this point, this library is not yet available through the Arduino Library manager. To install, following the following steps:

--- a/examples/sps30/sps30.ino
+++ b/examples/sps30/sps30.ino
@@ -38,6 +38,16 @@ void setup() {
 #ifndef PLOTTER_FORMAT
   Serial.print("measurements started\n");
 #endif /* PLOTTER_FORMAT */
+
+#ifdef SPS30_LIMITED_I2C_BUFFER_SIZE
+  Serial.print("Your Arduino hardware has a limitation that only\n");
+  Serial.print("  allows reading the mass concentrations. For more\n");
+  Serial.print("  information, please check\n");
+  Serial.print("  https://github.com/Sensirion/arduino-sps#esp8266-partial-legacy-support\n");
+  Serial.print("\n");
+  delay(2000);
+#endif
+
   delay(1000);
 }
 
@@ -74,6 +84,7 @@ void loop() {
     Serial.print("PM 10.0: ");
     Serial.println(m.mc_10p0);
 
+#ifndef SPS30_LIMITED_I2C_BUFFER_SIZE
     Serial.print("NC  0.5: ");
     Serial.println(m.nc_0p5);
     Serial.print("NC  1.0: ");
@@ -87,6 +98,8 @@ void loop() {
 
     Serial.print("Typical partical size: ");
     Serial.println(m.typical_particle_size);
+#endif
+
     Serial.println();
     
 #else

--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -35,6 +35,20 @@
 #define SPS30_USE_ALT_I2C
 #endif /* __AVR__ */
 
+/*
+ * ESP8266 core < 2.5.0 has a 32 byte I2C receive buffer in the Wire library
+ * Limit readout to PM mass concentrations
+ */
+#ifdef ESP8266
+#include <core_version.h>
+#if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || \
+    defined(ARDUINO_ESP8266_RELEASE_2_4_0) || \
+    defined(ARDUINO_ESP8266_RELEASE_2_4_1) || \
+    defined(ARDUINO_ESP8266_RELEASE_2_4_2)
+#define SPS30_LIMITED_I2C_BUFFER_SIZE
+#endif
+#endif /* ESP8266 */
+
 /**
  * If your platform does not provide the library stdint.h you have to
  * define the integral types yourself (see below).

--- a/sps30.cpp
+++ b/sps30.cpp
@@ -59,7 +59,8 @@ s16 sps30_probe() {
 
     sensirion_i2c_init();
 
-    return sps30_get_serial(serial);
+    u32 val;
+    return sps30_get_fan_auto_cleaning_interval(&val);
 }
 
 s16 sps30_get_serial(char *serial) {


### PR DESCRIPTION
allow limited functionality on platforms with 32 byte I2C buffer sizes; autodetect on platforms we know will have this problem (and are not AVR)