### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,18 +10,18 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-sps_get_driver_version KEYWORD2
-sps30_probe KEYWORD2
-sps30_get_serial KEYWORD2
-sps30_start_measurement KEYWORD2
-sps30_stop_measurement KEYWORD2
-sps30_read_data_ready KEYWORD2
-sps30_read_measurement KEYWORD2
-sps30_get_fan_auto_cleaning_interval KEYWORD2
-sps30_set_fan_auto_cleaning_interval KEYWORD2
-sps30_get_fan_auto_cleaning_interval_days KEYWORD2
-sps30_set_fan_auto_cleaning_interval_days KEYWORD2
-sps30_reset KEYWORD2
+sps_get_driver_version	KEYWORD2
+sps30_probe	KEYWORD2
+sps30_get_serial	KEYWORD2
+sps30_start_measurement	KEYWORD2
+sps30_stop_measurement	KEYWORD2
+sps30_read_data_ready	KEYWORD2
+sps30_read_measurement	KEYWORD2
+sps30_get_fan_auto_cleaning_interval	KEYWORD2
+sps30_set_fan_auto_cleaning_interval	KEYWORD2
+sps30_get_fan_auto_cleaning_interval_days	KEYWORD2
+sps30_set_fan_auto_cleaning_interval_days	KEYWORD2
+sps30_reset	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords