### PR TITLE
sensirion_i2c_read: change count to uint8_t to avoid compiler warnings

### DIFF
--- a/sensirion_hw_i2c_implementation.cpp
+++ b/sensirion_hw_i2c_implementation.cpp
@@ -90,7 +90,7 @@ void sensirion_i2c_release(void)
 {
 }
 
-int8_t sensirion_i2c_read(uint8_t address, uint8_t *data, uint16_t count) {
+int8_t sensirion_i2c_read(uint8_t address, uint8_t *data, uint8_t count) {
     uint8_t readData[count];
     uint8_t rxByteCount = 0;
 

--- a/sensirion_i2c.h
+++ b/sensirion_i2c.h
@@ -71,7 +71,7 @@ void sensirion_i2c_release(void);
  * @param count   number of bytes to read from I2C and store in the buffer
  * @returns 0 on success, error code otherwise
  */
-int8_t sensirion_i2c_read(uint8_t address, uint8_t *data, uint16_t count);
+int8_t sensirion_i2c_read(uint8_t address, uint8_t *data, uint8_t count);
 
 /**
  * Execute one write transaction on the I2C bus, sending a given number of


### PR DESCRIPTION
On some arduino architectures the current implementation causes compiler warnings as there is no implementation for 
 uint8_t requestFrom(uint8_t address, uint16_t size) in the wire library. 
Example is the esp32 architecture. 
I think it is save to change it to uint8_t to avoid these warnings.

Signed-off-by: Volker <15142022+moeskerv@users.noreply.github.com>