### PR TITLE
Quick fix: don't enable I2C master lib on MegaAvr

### DIFF
--- a/sensirion_arch_config.h
+++ b/sensirion_arch_config.h
@@ -35,9 +35,13 @@
 /*
  * AVR Arduinos have a 32 byte I2C receive buffer in the Wire library
  * Use alternative I2C implementation to work around that
+ *
+ * TODO: change this to a more targetted selection, i.e. __AVR_ATmega328P__ etc vs __AVR__
  */
 #ifdef __AVR__
-#define SPS30_USE_ALT_I2C
+  #ifndef ARDUINO_ARCH_MEGAAVR
+     #define SPS30_USE_ALT_I2C
+  #endif
 #endif /* __AVR__ */
 
 /*


### PR DESCRIPTION
The I2C master lib is specifically for the register names used in Arduinos like the Uno, which use the ATMega328P. On models like the ATMega4809, this does not work, and is in fact not necessary since the I2C buffer size seems to be 128 bytes to begin with

This change is not ideal and should be replaced with an explicit selection of the platforms that actually require the alternative I2C library, but it allows users to work on ATMega4809 for the time being