### PR TITLE
Allow using secondary Wire buses

### DIFF
--- a/sensirion_hw_i2c_implementation.cpp
+++ b/sensirion_hw_i2c_implementation.cpp
@@ -37,12 +37,6 @@
 
 #include <Wire.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-
-
 #ifdef SPS30_USE_ALT_I2C
 #include "i2c_master_lib.h"
 
@@ -129,7 +123,3 @@ int8_t sensirion_i2c_write(uint8_t address, const uint8_t *data,
 void sensirion_sleep_usec(uint32_t useconds) {
     delay((useconds / 1000) + 1);
 }
-
-#ifdef __cplusplus
-}  // extern "C"
-#endif

--- a/sensirion_hw_i2c_implementation.cpp
+++ b/sensirion_hw_i2c_implementation.cpp
@@ -35,8 +35,6 @@
 // needed for delay() routine
 #include <Arduino.h>
 
-#include <Wire.h>
-
 #ifdef SPS30_USE_ALT_I2C
 #include "i2c_master_lib.h"
 
@@ -78,10 +76,15 @@ static TwoWire *sensirion_wire_object;
  * communication. After this function has been called, the functions
  * i2c_read() and i2c_write() must succeed.
  */
+void sensirion_i2c_init(TwoWire& wire)
+{
+   sensirion_wire_object = &wire;
+   sensirion_wire_object->begin();
+}
+
 void sensirion_i2c_init()
 {
-   sensirion_wire_object = &Wire;
-   sensirion_wire_object->begin();
+    sensirion_i2c_init(Wire);
 }
 
 void sensirion_i2c_release(void)

--- a/sensirion_i2c.h
+++ b/sensirion_i2c.h
@@ -33,6 +33,18 @@
 #define SENSIRION_I2C_H
 
 #include "sensirion_arch_config.h"
+#if defined(__cplusplus)
+#include <Wire.h>
+#endif
+
+// When included from C++, add a version of the init function that
+// accepts a Wire bus to use (in addition to the argumentless C-linkage
+// version defined below.
+// If SPS30_USE_ALT_I2C is defined, a fixed (local) I2C implementation
+// is used instead.
+#if !defined(SPS30_USE_ALT_I2C) && defined(__cplusplus)
+void sensirion_i2c_init(TwoWire& wire);
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sensirion_i2c.h
+++ b/sensirion_i2c.h
@@ -39,18 +39,6 @@ extern "C" {
 #endif /* __cplusplus */
 
 /**
- * Select the current i2c bus by index.
- * All following i2c operations will be directed at that bus.
- *
- * THE IMPLEMENTATION IS OPTIONAL ON SINGLE-BUS SETUPS (all sensors on the same
- * bus)
- *
- * @param bus_idx   Bus index to select
- * @returns         0 on success, an error code otherwise
- */
-int16_t sensirion_i2c_select_bus(uint8_t bus_idx);
-
-/**
  * Initialize all hard- and software components that are needed for the I2C
  * communication.
  */

--- a/sps30.h
+++ b/sps30.h
@@ -32,13 +32,14 @@
 #ifndef SPS30_H
 #define SPS30_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "sensirion_arch_config.h"
 #include "sensirion_common.h"
 #include "sensirion_i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define SPS30_I2C_ADDRESS 0x69
 #define SPS30_MAX_SERIAL_LEN 32


### PR DESCRIPTION
This allows passing a Wire bus object to `sensirion_i2c_init()` to allow using other buses than the default `Wire` (such as `Wire1` for the secondary bus.

This implementation is based on discussion in #23 (and fixes that issue).

This change should be fully backward compatible. Some care has been taken to even keep C-code that would use this library working (compile-tested, not runtime tested).

This PR assumes that the type of wire objects is "TwoWire", which seems to be true for the AVR, STM32Duino, STM32L0, ESP8266, ESP32 and MegaAVR cores at least. If there is ever a core that has a different type, that could be fixed with something like:

```C++
  #if __cpp_decltype >= 200707L                                                                       
  // Just in case some Arduino core uses a different type for its Wire                                
  // objects, autodetect it.                                                                          
>>typedef decltype(Wire) Wire_t;                                                                      
  #else                                                                                               
  // If we do not have decltype, make an assumption about the type name                               
  typedef TwoWire Wire_t;                                                                             
  #endif   
```
But I do not think it is worth complicating the code with this if there seems to be no core that needs it.

I have tested this code with the https://github.com/GrumpyOldPizza/ArduinoCore-stm32l0/ (and a custom-made STM32L0-based device) since that is the only device I have that has a connector for the SPS030 :-)

The PR is divided into a few different commits, first doing some small cleanups/refactorings, with the actual changes happening in the last two commits. Probably best reviewed commit-by-commit, but the total change is small enough to also allow reviewing the entire thing in one go.

This fixes #23.