### PR TITLE
Do not assume the Wire bus type is TwoWire

### DIFF
--- a/sensirion_hw_i2c_implementation.cpp
+++ b/sensirion_hw_i2c_implementation.cpp
@@ -69,14 +69,14 @@ int8_t sensirion_i2c_write(uint8_t address, const uint8_t *data, uint8_t count)
 
 #else /* SPS30_USE_ALT_I2C */
 
-static TwoWire *sensirion_wire_object;
+static SensirionWire_t *sensirion_wire_object;
 
 /**
  * Initialize all hard- and software components that are needed for the I2C
  * communication. After this function has been called, the functions
  * i2c_read() and i2c_write() must succeed.
  */
-void sensirion_i2c_init(TwoWire& wire)
+void sensirion_i2c_init(SensirionWire_t& wire)
 {
    sensirion_wire_object = &wire;
    sensirion_wire_object->begin();

--- a/sensirion_i2c.h
+++ b/sensirion_i2c.h
@@ -43,7 +43,15 @@
 // If SPS30_USE_ALT_I2C is defined, a fixed (local) I2C implementation
 // is used instead.
 #if !defined(SPS30_USE_ALT_I2C) && defined(__cplusplus)
-void sensirion_i2c_init(TwoWire& wire);
+#  if __cpp_decltype >= 200707L
+// Not all cores use the same typename (e.g. SAMD uses arduino::TwoWire), so
+// deduce the type (and assume all Wire buses use the same type).
+typedef decltype(Wire) SensirionWire_t;
+#  else
+// If we do not have decltype, make an assumption about the type name
+typedef TwoWire SensirionWire_t;
+#  endif
+void sensirion_i2c_init(SensirionWire_t& wire);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Turns out it is arduino::TwoWire on SAMD at least, so use decltype to derive the type of the Wire object (which should be standardized) and use that.

This fixes compiling the library on SAMD. This was broken by #54 in v1.2.0.